### PR TITLE
Migrate to PHP7.0.x fix

### DIFF
--- a/includes/ip2c/ip2c.php
+++ b/includes/ip2c/ip2c.php
@@ -17,7 +17,7 @@ class ip2country
 	 * ip2country(String $file, true) will USE caching with default file location
 	 * ip2country(Boolean true) will USE caching with default file location
 	 */
-	function ip2country($bin_file = './ip-to-country.bin', $caching = false) 
+	function __construct($bin_file = './ip-to-country.bin', $caching = false) 
 	{
 		if (is_bool($bin_file)) {
 			// use $bin_file as caching indicator


### PR DESCRIPTION
Migrating from PHP 5.6.x to PHP 7.0.x fix

> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP 

http://php.net/manual/ja/migration70.deprecated.php